### PR TITLE
Call drush command to update permissions

### DIFF
--- a/terminus-update-dev
+++ b/terminus-update-dev
@@ -21,5 +21,6 @@ if [[ "${CURRENT_UPSTREAM}" == "3162cc4c-2f75-40cb-8487-0c69bda99f39" ]]; then
   terminus drush ${SITE_NAME}.dev -- -n -y updatedb
   terminus drush ${SITE_NAME}.dev -- -n -y state:set config_sync.update_mode 1 --input-format=integer
   terminus drush ${SITE_NAME}.dev -- -n -y config-distro-update
+  terminus drush ${SITE_NAME}.dev -- -n -y az-core-config-add-permissions
 fi
 

--- a/terminus-update-live
+++ b/terminus-update-live
@@ -14,6 +14,7 @@ CURRENT_UPSTREAM=$(terminus site:info ${SITE_NAME} --field upstream | sed 's/:.*
 if [[ "${CURRENT_UPSTREAM}" == "3162cc4c-2f75-40cb-8487-0c69bda99f39" ]]; then
   terminus drush ${SITE_NAME}.live -- -n -y state:set config_sync.update_mode 1 --input-format=integer
   terminus drush ${SITE_NAME}.live -- -n -y config-distro-update
+  terminus drush ${SITE_NAME}.live -- -n -y az-core-config-add-permissions
 fi
 
 terminus env:clear-cache ${SITE_NAME}.live

--- a/terminus-update-test
+++ b/terminus-update-test
@@ -17,6 +17,7 @@ CURRENT_UPSTREAM=$(terminus site:info ${SITE_NAME} --field upstream | sed 's/:.*
 if [[ "${CURRENT_UPSTREAM}" == "3162cc4c-2f75-40cb-8487-0c69bda99f39" ]]; then
   terminus drush ${SITE_NAME}.test -- -n -y state:set config_sync.update_mode 1 --input-format=integer
   terminus drush ${SITE_NAME}.test -- -n -y config-distro-update
+  terminus drush ${SITE_NAME}.test -- -n -y az-core-config-add-permissions
 fi
 
 terminus env:clear-cache ${SITE_NAME}.test


### PR DESCRIPTION
Adds a call to a drush script to update/install new permissions from the az-quickstart installation profile.

resolves #10